### PR TITLE
Avoid ArgumentException

### DIFF
--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SKColorFactory.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SKColorFactory.cs
@@ -17,7 +17,7 @@ public static class SKColorFactory
         if (!_colours.TryGetValue(key, out SKColor color))
         {
             color = new SKColor(red, green, blue, alpha);
-            _colours.Add(key, color);
+            _colours[key] = color;
 
 #if DEBUG_COLORS
             log.Debug($"{callerName} -> Created {key} :: SKColorFactory.MakeColor({red}, {green}, {blue}, {alpha})");


### PR DESCRIPTION
The sample [here](https://github.com/Mapsui/Mapsui/pull/2938) shows two exception in the log. It seems both are caused by the `Add`. In Mapsui we use multiple threads to fetch tiles and in this case render tiles. This causes the key to be added multiple times. When I set the number of threads in the fetcher to 1 the exception does not occur.

Using an assignment (`_colours[key] = color`) the line will still be called twice but the second time it will simply overwrite the existing entry.

The exception:
```console
System.ArgumentException:  An element with the same key already exists in the System.Collections.Generic.Dictionary
```