### PR TITLE
Feature/explore why land is rendered as sea

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BruTile" Version="5.0.6" />
@@ -11,11 +11,13 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NLog" Version="5.0.0" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.7" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.9" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="Svg" Version="3.4.7" />
     <PackageVersion Include="Svg.Skia" Version="1.0.0.3" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
     <PackageVersion Include="VexTile.Clipper" Version="6.4.0" />
     <PackageVersion Include="VexTile.Mapbox.VectorTile.ExtensionMethods" Version="1.0.6" />
     <PackageVersion Include="VexTile.Mapbox.VectorTile.Geometry" Version="1.0.6" />

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux.Tests/RenderTest.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux.Tests/RenderTest.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Threading.Tasks;
 using SQLite;
@@ -100,5 +102,38 @@ public class RenderTest
         }
 
         await File.WriteAllBytesAsync("test2.png", tile);
+    }
+
+
+    [Fact]
+    public async Task AAABasicFactoryRenderTest()
+    {
+        var canvas = new SkiaCanvas();
+        var style = new VectorStyle(VectorStyleKind.Default);
+
+        string path = "zurich.mbtiles";
+        Assert.True(File.Exists(path));
+
+        SQLiteConnectionString val = new(path, SQLiteOpenFlags.ReadOnly, false);
+        var dataSource = new SqliteDataSource(val);
+        var provider = new VectorTilesSource(dataSource);
+        style.SetSourceProvider("openmaptiles", provider);
+
+        var info = new TileInfo(3, 1, 2, layerWhiteList:["water"]); // australia
+        var tile = await TileRendererFactory.RenderAsync(style, canvas, info);
+
+        Assert.NotNull(tile);
+        Assert.True(tile.Length > 0);
+
+        // tile should be a PNG image
+
+        Assert.True(IsPng(tile));
+
+        if (File.Exists("aaa.png"))
+        {
+            File.Delete("aaa.png");
+        }
+
+        await File.WriteAllBytesAsync("aaa.png", tile);
     }
 }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux.Tests/RenderTest.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux.Tests/RenderTest.cs
@@ -106,7 +106,7 @@ public class RenderTest
 
 
     [Fact]
-    public async Task AAABasicFactoryRenderTest()
+    public async Task BasicFactoryRenderTest_WaterOnly()
     {
         var canvas = new SkiaCanvas();
         var style = new VectorStyle(VectorStyleKind.Default);
@@ -129,11 +129,11 @@ public class RenderTest
 
         Assert.True(IsPng(tile));
 
-        if (File.Exists("aaa.png"))
+        if (File.Exists("wateronly.png"))
         {
-            File.Delete("aaa.png");
+            File.Delete("wateronly.png");
         }
 
-        await File.WriteAllBytesAsync("aaa.png", tile);
+        await File.WriteAllBytesAsync("wateronly.png", tile);
     }
 }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/DoubleExtension.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/DoubleExtension.cs
@@ -2,18 +2,11 @@
 
 namespace VexTile.Renderer.Mvt.AliFlux;
 
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S125:Sections of code should not be commented out", Justification = "<Pending>")]
 internal static class DoubleExtension
 {
     //private const double DefaultPrecision = 0.0001;
 
-    internal static bool BasicallyEqualTo(this double a, double b)
-    {
-        return a.BasicallyEqualTo(b, 0.0001);
-    }
+    internal static bool BasicallyEqualTo(this double a, double b) => a.BasicallyEqualTo(b, 0.0001);
 
-    private static bool BasicallyEqualTo(this double a, double b, double precision)
-    {
-        return Math.Abs(a - b) <= precision;
-    }
+    private static bool BasicallyEqualTo(this double a, double b, double precision) => Math.Abs(a - b) <= precision;
 }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Drawing/VisualLayer.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Drawing/VisualLayer.cs
@@ -15,5 +15,8 @@ public class VisualLayer
 
     public Brush Brush { get; set; }
 
-    public string Id { get; set; } = "";
+    public string Id => $"{LayerId} :: {SourceName} :: {SourceLayer}";
+    public string LayerId { get; set; }
+    public string SourceName { get; set; }
+    public string SourceLayer { get; set; }
 }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/ICanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/ICanvas.cs
@@ -10,11 +10,13 @@ public interface ICanvas
 
     void StartDrawing(double width, double height);
 
-    void DrawBackground(Brush style);
+    SKColor BackgroundColor { get; }
+
+    void DrawBackground(SKColor color);
 
     void DrawLineString(List<Point> geometry, Brush style);
 
-    void DrawPolygon(List<Point> geometry, Brush style);
+    void DrawPolygon(List<Point> geometry, Brush style, SKColor? background);
 
     void DrawPoint(Point geometry, Brush style);
 

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/ICanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/ICanvas.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using SkiaSharp;
 using VexTile.Renderer.Mvt.AliFlux.Drawing;
 
 namespace VexTile.Renderer.Mvt.AliFlux;
@@ -24,6 +25,8 @@ public interface ICanvas
     void DrawImage(byte[] imageData, Brush style);
 
     void DrawUnknown(List<List<Point>> geometry, Brush style);
+
+    void DrawDebugBox(TileInfo tileData, SKColor color);
 
     byte[] FinishDrawing();
 }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/LineClipper.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/LineClipper.cs
@@ -8,7 +8,7 @@ namespace VexTile.Renderer.Mvt.AliFlux;
 
 internal static class LineClipper
 {
-    static readonly NLog.Logger log = NLog.LogManager.GetCurrentClassLogger();
+    private static readonly NLog.Logger Log = NLog.LogManager.GetCurrentClassLogger();
 
     private static OutCode ComputeOutCode(double x, double y, Rect r)
     {
@@ -37,7 +37,7 @@ internal static class LineClipper
         return code;
     }
 
-    private static OutCode ComputeOutCode(Point p, Rect r) { return ComputeOutCode(p.X, p.Y, r); }
+    private static OutCode ComputeOutCode(Point p, Rect r) => ComputeOutCode(p.X, p.Y, r);
 
     private static Point CalculateIntersection(Rect r, Point p1, Point p2, OutCode clipTo)
     {
@@ -216,7 +216,7 @@ internal static class LineClipper
             }
             else
             {
-                log.Debug("Segment is null");
+                Log.Debug("Segment is null");
             }
         }
 

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SKColorFactory.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SKColorFactory.cs
@@ -7,17 +7,17 @@ namespace VexTile.Renderer.Mvt.AliFlux;
 // ReSharper disable once InconsistentNaming
 public static class SKColorFactory
 {
-    private static readonly Dictionary<string, SKColor> _colours = new();
+    private static readonly Dictionary<string, SKColor> Colours = new();
 
     // try to centralise this as tracking down where colours ar made is hard
     public static SKColor MakeColor(byte red, byte green, byte blue, byte alpha = 255, [CallerMemberName] string callerName = "<unknown>")
     {
         string key = MakeKey(red, green, blue, alpha);
 
-        if (!_colours.TryGetValue(key, out SKColor color))
+        if (!Colours.TryGetValue(key, out SKColor color))
         {
             color = new SKColor(red, green, blue, alpha);
-            _colours[key] = color;
+            Colours[key] = color;
 
 #if DEBUG_COLORS
             log.Debug($"{callerName} -> Created {key} :: SKColorFactory.MakeColor({red}, {green}, {blue}, {alpha})");
@@ -44,9 +44,9 @@ public static class SKColorFactory
     {
         string key = MakeKey(color.Red, color.Green, color.Blue, color.Alpha);
 
-        if (!_colours.TryGetValue(key, out _))
+        if (!Colours.TryGetValue(key, out _))
         {
-            _colours.Add(key, color);
+            Colours.Add(key, color);
         }
         return color;
     }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
@@ -16,7 +16,7 @@ namespace VexTile.Renderer.Mvt.AliFlux;
 
 public class SkiaCanvas : ICanvas
 {
-    readonly NLog.Logger log =  NLog.LogManager.GetCurrentClassLogger();
+    readonly NLog.Logger log = NLog.LogManager.GetCurrentClassLogger();
 
     private int _width;
     private int _height;
@@ -53,8 +53,7 @@ public class SkiaCanvas : ICanvas
         };
     }
 
-    public void DrawBackground(Brush style) =>
-        _canvas.Clear(SKColorFactory.MakeColor(style.Paint.BackgroundColor.Red, style.Paint.BackgroundColor.Green, style.Paint.BackgroundColor.Blue, style.Paint.BackgroundColor.Alpha));
+    public void DrawBackground(Brush style) => _canvas.Clear(SKColorFactory.MakeColor(style.Paint.BackgroundColor.Red, style.Paint.BackgroundColor.Green, style.Paint.BackgroundColor.Blue, style.Paint.BackgroundColor.Alpha));
 
     private SKStrokeCap ConvertCap(PenLineCap cap)
     {
@@ -71,10 +70,7 @@ public class SkiaCanvas : ICanvas
         return SKStrokeCap.Square;
     }
 
-    private double Clamp(double number, double min = 0, double max = 1)
-    {
-        return Math.Max(min, Math.Min(max, number));
-    }
+    private double Clamp(double number, double min = 0, double max = 1) { return Math.Max(min, Math.Min(max, number)); }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S1168:Empty arrays and collections should be returned instead of null", Justification = "<Pending>")]
     private List<List<Point>> ClipPolygon(List<Point> geometry) // may break polygons into multiple ones
@@ -456,13 +452,9 @@ public class SkiaCanvas : ICanvas
         return distance;
     }
 
-    private Vector Subtract(Point point1, Point point2)
-    {
-        return new Vector(point1.X - point2.X, point1.Y - point2.Y);
-    }
+    private Vector Subtract(Point point1, Point point2) { return new Vector(point1.X - point2.X, point1.Y - point2.Y); }
 
-    private double GetAbsoluteDiff2Angles(double x, double y, double c = Math.PI) =>
-        c - Math.Abs((Math.Abs(x - y) % 2 * c) - c);
+    private double GetAbsoluteDiff2Angles(double x, double y, double c = Math.PI) => c - Math.Abs((Math.Abs(x - y) % 2 * c) - c);
 
     private bool CheckPathSqueezing(List<Point> path, double textHeight)
     {
@@ -563,8 +555,8 @@ public class SkiaCanvas : ICanvas
         {
             //  implement this func custom way...
             _canvas.DrawTextOnPath(text, path, offset, true, GetTextStrokePaint(style));
-
         }
+
         _canvas.DrawTextOnPath(text, path, offset, true, GetTextPaint(style));
     }
 
@@ -604,7 +596,10 @@ public class SkiaCanvas : ICanvas
                 return;
             }
 
-            var tcolor = style.Paint.FillColor;
+
+            var tcolor = !IsClockwise(geometry)
+                ? style.Paint.FillColor
+                : SKColors.Azure;
 
             var color = SKColorFactory.MakeColor(tcolor.Red, tcolor.Green, tcolor.Blue, (byte)Clamp(tcolor.Alpha * style.Paint.FillOpacity, 0, 255));
 
@@ -618,6 +613,19 @@ public class SkiaCanvas : ICanvas
 
             _canvas.DrawPath(path, fillPaint);
         }
+    }
+
+    private static bool IsClockwise(List<Point> polygon)
+    {
+        double sum = 0.0;
+        for (int i = 0; i < polygon.Count; i++)
+        {
+            Point v1 = polygon[i];
+            Point v2 = polygon[(i + 1) % polygon.Count];
+            sum += (v2.X - v1.X) * (v2.Y + v1.Y);
+        }
+
+        return sum > 0.0;
     }
 
     public void DrawImage(byte[] imageData, Brush style)
@@ -634,19 +642,17 @@ public class SkiaCanvas : ICanvas
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Critical Code Smell", "S1186:Methods should not be empty", Justification = "Third party")]
-    public void DrawUnknown(List<List<Point>> geometry, Brush style)
-    {
-    }
+    public void DrawUnknown(List<List<Point>> geometry, Brush style) { }
 
     public void DrawDebugBox(TileInfo tileData, SKColor color)
     {
-        _surface.Canvas.DrawRect(new SKRect(0,0,_width,_height), new SKPaint
+        _surface.Canvas.DrawRect(new SKRect(0, 0, _width, _height), new SKPaint
         {
             Color = color,
             Style = SKPaintStyle.Stroke,
         });
 
-        _surface.Canvas.DrawText($"({tileData.X}, {tileData.Y}, {(int)tileData.Zoom})", new SKPoint(20,20), new SKPaint
+        _surface.Canvas.DrawText($"({tileData.X}, {tileData.Y}, {(int)tileData.Zoom})", new SKPoint(20, 20), new SKPaint
         {
             FakeBoldText = true,
             TextSize = 14,

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
@@ -53,7 +53,13 @@ public class SkiaCanvas : ICanvas
         };
     }
 
-    public void DrawBackground(Brush style) => _canvas.Clear(SKColorFactory.MakeColor(style.Paint.BackgroundColor.Red, style.Paint.BackgroundColor.Green, style.Paint.BackgroundColor.Blue, style.Paint.BackgroundColor.Alpha));
+    SKColor _backgroundColor = SKColors.White;
+
+    public void DrawBackground(Brush style)
+    {
+        _backgroundColor = style.Paint.BackgroundColor; // we cache this
+        _canvas.Clear(SKColorFactory.MakeColor(style.Paint.BackgroundColor.Red, style.Paint.BackgroundColor.Green, style.Paint.BackgroundColor.Blue, style.Paint.BackgroundColor.Alpha));
+    }
 
     private SKStrokeCap ConvertCap(PenLineCap cap)
     {
@@ -633,11 +639,14 @@ public class SkiaCanvas : ICanvas
             }
 
 
-            var tcolor = !IsClockwise(geometry)
-                ? style.Paint.FillColor
-                : SKColors.Azure;
 
-            var color = SKColorFactory.MakeColor(tcolor.Red, tcolor.Green, tcolor.Blue, (byte)Clamp(tcolor.Alpha * style.Paint.FillOpacity, 0, 255));
+            var color = !IsClockwise(geometry)
+                ? SKColorFactory.MakeColor(
+                    style.Paint.FillColor.Red,
+                    style.Paint.FillColor.Green,
+                    style.Paint.FillColor.Blue,
+                    (byte)Clamp(style.Paint.FillColor.Alpha * style.Paint.FillOpacity, 0, 255))
+                : _backgroundColor;
 
             SKPaint fillPaint = new SKPaint
             {

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
@@ -638,6 +638,23 @@ public class SkiaCanvas : ICanvas
     {
     }
 
+    public void DrawDebugBox(TileInfo tileData, SKColor color)
+    {
+        _surface.Canvas.DrawRect(new SKRect(0,0,_width,_height), new SKPaint
+        {
+            Color = color,
+            Style = SKPaintStyle.Stroke,
+        });
+
+        _surface.Canvas.DrawText($"({tileData.X}, {tileData.Y}, {(int)tileData.Zoom})", new SKPoint(20,20), new SKPaint
+        {
+            FakeBoldText = true,
+            TextSize = 14,
+            Color = color,
+            Style = SKPaintStyle.Stroke,
+        });
+    }
+
     public byte[] FinishDrawing()
     {
         using var image = _surface.Snapshot();

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
@@ -550,10 +550,12 @@ public class SkiaCanvas : ICanvas
 
         var bounds = path.Bounds;
 
-        double left = bounds.Left - style.Paint.TextSize;
-        double top = bounds.Top - style.Paint.TextSize;
-        double right = bounds.Right + style.Paint.TextSize;
-        double bottom = bounds.Bottom + style.Paint.TextSize;
+        double hedge = 2;
+
+        double left = bounds.Left - style.Paint.TextSize - hedge;
+        double top = bounds.Top - style.Paint.TextSize - hedge;
+        double right = bounds.Right + style.Paint.TextSize + hedge;
+        double bottom = bounds.Bottom + style.Paint.TextSize + hedge;
 
         var rectangle = new Rect(left, top, right - left, bottom - top);
 

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
@@ -103,7 +103,7 @@ public class SkiaCanvas : ICanvas
 
     private SKPath GetPathFromGeometry(List<Point> geometry)
     {
-        SKPath path = new SKPath
+        SKPath path = new()
         {
             FillType = SKPathFillType.EvenOdd,
         };
@@ -118,6 +118,22 @@ public class SkiaCanvas : ICanvas
         }
 
         return path;
+    }
+
+    private static bool IsLeftToRight(List<Point> geometry)
+    {
+        var firstPoint = geometry[0];
+        var lastPoint = geometry[geometry.Count - 1];
+
+        return  (firstPoint.X <= lastPoint.X);
+    }
+
+    private static bool IsTopToBottom(List<Point> geometry)
+    {
+        var firstPoint = geometry[0];
+        var lastPoint = geometry[geometry.Count - 1];
+
+        return  (firstPoint.Y > lastPoint.Y);
     }
 
     public void DrawLineString(List<Point> geometry, Brush style)
@@ -508,7 +524,23 @@ public class SkiaCanvas : ICanvas
             return;
         }
 
-        var path = GetPathFromGeometry(geometry);
+        // is the path | ----> | or | <---- | ?
+
+        var ltr = IsLeftToRight(geometry);
+        var ttb = IsTopToBottom(geometry);
+
+        SKPath path;
+        if (ltr)
+        {
+            path = GetPathFromGeometry(geometry);
+        }
+        else
+        {
+            var pathPoints = new List<Point>(geometry);
+            pathPoints.Reverse();
+            path = GetPathFromGeometry(pathPoints);
+        }
+
         string text = TransformText(style.Text, style);
 
         if (CheckPathSqueezing(geometry, style.Paint.TextSize))
@@ -558,6 +590,8 @@ public class SkiaCanvas : ICanvas
         }
 
         _canvas.DrawTextOnPath(text, path, offset, true, GetTextPaint(style));
+
+
     }
 
     public void DrawPoint(Point geometry, Brush style)

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Sources/PbfTileSource.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Sources/PbfTileSource.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Threading.Tasks;
 using VexTile.Mapbox.VectorTile.Geometry;
 using VexTile.Renderer.Mvt.AliFlux.Drawing;

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRendererFactory.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRendererFactory.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// defining this will add a box around the tile boundary and also
+// burn in the XYZ value of the tile. This is very handy for debugging
+//#define USE_DEBUG_BOX
+
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -283,7 +287,9 @@ public static class TileRendererFactory
             }
         }
 
+#if USE_DEBUG_BOX
         canvas.DrawDebugBox(tileData, SKColors.Black);
+#endif
 
         return canvas.FinishDrawing();
     }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRendererFactory.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRendererFactory.cs
@@ -7,6 +7,7 @@ using SkiaSharp;
 using VexTile.Renderer.Mvt.AliFlux.Drawing;
 using VexTile.Renderer.Mvt.AliFlux.Enums;
 using VexTile.Renderer.Mvt.AliFlux.Sources;
+using Point = VexTile.Renderer.Mvt.AliFlux.Drawing.Point;
 
 namespace VexTile.Renderer.Mvt.AliFlux;
 
@@ -30,7 +31,7 @@ public static class TileRendererFactory
     /// <param name="whiteListLayers">optional whitelist to reduce layers to render</param>
     /// <returns>a png</returns>
     public static async Task<byte[]> RenderAsync(VectorStyle style, ICanvas canvas, int x, int y, double zoom, double sizeX = 512, double sizeY = 512, double scale = 1, List<string> whiteListLayers = null, Color? overrideBackground = null) =>
-        await  RenderAsync(style, canvas,
+        await RenderAsync(style, canvas,
             new TileInfo(x, y, zoom, sizeX, sizeY, scale, whiteListLayers), overrideBackground);
 
     /// <summary>
@@ -174,10 +175,11 @@ public static class TileRendererFactory
                 var brushes = style.GetStyleByType("background", actualZoom, tileData.Scale);
                 foreach (var brush in brushes)
                 {
-                    if (overrideBackground is {} c)
+                    if (overrideBackground is { } c)
                     {
                         brush.Paint.BackgroundColor = new SKColor(c.R, c.G, c.B, c.A);
                     }
+
                     canvas.DrawBackground(brush);
                 }
             }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Utils.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Utils.cs
@@ -8,25 +8,24 @@ internal static class Utils
 {
     public static double ConvertRange(double oldValue, double oldMin, double oldMax, double newMin, double newMax, bool clamp = false)
     {
-        double NewRange;
-        double NewValue;
-        double OldRange = (oldMax - oldMin);
-        if (OldRange == 0)
+        double newValue;
+        double oldRange = (oldMax - oldMin);
+        if (oldRange == 0)
         {
-            NewValue = newMin;
+            newValue = newMin;
         }
         else
         {
-            NewRange = (newMax - newMin);
-            NewValue = (((oldValue - oldMin) * NewRange) / OldRange) + newMin;
+            var newRange = (newMax - newMin);
+            newValue = (((oldValue - oldMin) * newRange) / oldRange) + newMin;
         }
 
         if (clamp)
         {
-            NewValue = Math.Min(Math.Max(NewValue, newMin), newMax);
+            newValue = Math.Min(Math.Max(newValue, newMin), newMax);
         }
 
-        return NewValue;
+        return newValue;
     }
 
     public static string Sha256(string randomString)

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/VexTile.Renderer.Mvt.AliFlux.csproj
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/VexTile.Renderer.Mvt.AliFlux.csproj
@@ -4,6 +4,7 @@
         <Configurations>Debug;Release</Configurations>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>disable</Nullable>
+        <Copyright>Copyright (c) 2018 Ali Ashraf, 2019-2025 Matt Emson</Copyright>
         <Title>VexTile AliFlux Mapbox Vector Tile Renderer</Title>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Description>A comprehensive Mapbox Vector Tile Renderer for .Net/C#, based on the AliFlux.VectorTileRenderer</Description>

--- a/source/Mapping/VexTile.MbTiles.Mvt.TestApp/MainWindow.axaml.cs
+++ b/source/Mapping/VexTile.MbTiles.Mvt.TestApp/MainWindow.axaml.cs
@@ -13,7 +13,7 @@ public partial class MainWindow : Window
         InitializeComponent();
 
         var connectionString = new SQLiteConnectionString("zurich.mbtiles", SQLiteOpenFlags.ReadOnly, false);
-        var source = new MvtVectorTileSource(connectionString, whitelist: ["landcover"]);
+        var source = new MvtVectorTileSource(connectionString, whitelist: ["water"]);
         var tileLayer = new TileLayer(source);
         TheMap.Map.Layers.Add(tileLayer);
     }

--- a/source/Mapping/VexTile.MbTiles.Mvt.TestApp/MainWindow.axaml.cs
+++ b/source/Mapping/VexTile.MbTiles.Mvt.TestApp/MainWindow.axaml.cs
@@ -13,7 +13,7 @@ public partial class MainWindow : Window
         InitializeComponent();
 
         var connectionString = new SQLiteConnectionString("zurich.mbtiles", SQLiteOpenFlags.ReadOnly, false);
-        var source = new MvtVectorTileSource(connectionString, whitelist: ["water"]);
+        var source = new MvtVectorTileSource(connectionString, determineExtent: false);
         var tileLayer = new TileLayer(source);
         TheMap.Map.Layers.Add(tileLayer);
     }

--- a/source/Mapping/VexTile.MbTiles.Mvt.TestApp/MainWindow.axaml.cs
+++ b/source/Mapping/VexTile.MbTiles.Mvt.TestApp/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using BruTile.MbTiles;
 using Mapsui.Tiling.Layers;
 using SQLite;
 using VexTile.TileSource.Mvt;
@@ -12,7 +13,7 @@ public partial class MainWindow : Window
         InitializeComponent();
 
         var connectionString = new SQLiteConnectionString("zurich.mbtiles", SQLiteOpenFlags.ReadOnly, false);
-        var source = new MvtVectorTileSource(connectionString);
+        var source = new MvtVectorTileSource(connectionString, whitelist: ["landcover"]);
         var tileLayer = new TileLayer(source);
         TheMap.Map.Layers.Add(tileLayer);
     }

--- a/source/Mapping/VexTile.MbTiles.Mvt.TestApp/VexTile.MbTiles.Mvt.TestApp.csproj
+++ b/source/Mapping/VexTile.MbTiles.Mvt.TestApp/VexTile.MbTiles.Mvt.TestApp.csproj
@@ -18,18 +18,28 @@
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Mapsui.Avalonia" />
+        <PackageReference Include="Mapsui.Avalonia"/>
         <PackageReference Include="sqlite-net-pcl"/>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\VexTile.MbTiles.Mvt\VexTile.MbTiles.Mvt.csproj" />
+        <ProjectReference Include="..\VexTile.MbTiles.Mvt\VexTile.MbTiles.Mvt.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
-      <Content Include="..\..\..\tiles\zurich.mbtiles">
-        <Link>zurich.mbtiles</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
+        <Content Include="..\..\..\tiles\zurich.mbtiles">
+            <Link>zurich.mbtiles</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
+
+    <PropertyGroup>
+        <ErrorReport>prompt</ErrorReport>
+        <!--
+            NU1803 - Nuget https transition warning
+            NU1701 - package was restored with older framework - package may not be compatible with framework in use
+            NU1702 - multi targeting - package may not be compatible with framework in use
+        -->
+        <NoWarn>$(NoWarn);NU1803;NU1701;NU1702;NETSDK1206</NoWarn>
+    </PropertyGroup>
 </Project>

--- a/source/Mapping/VexTile.MbTiles.Mvt/MvtVectorTileSource.cs
+++ b/source/Mapping/VexTile.MbTiles.Mvt/MvtVectorTileSource.cs
@@ -217,9 +217,7 @@ public class MvtVectorTileSource : ITileSource
                     _style,
                     canvas,
                     tileInfo.Index.Col, tileInfo.Index.Row, Convert.ToInt32(tileInfo.Index.Level),
-                    256, 256, 1,
-                    null, //whitelist,
-                    Color.Red);
+                    256, 256, 1);
             }
             catch(Exception ex)
             {

--- a/source/Mapping/VexTile.MbTiles.Mvt/MvtVectorTileSource.cs
+++ b/source/Mapping/VexTile.MbTiles.Mvt/MvtVectorTileSource.cs
@@ -1,6 +1,7 @@
-﻿#define DEBUG_EXTENT
+﻿//Define this to make the extent the entire world, rather than just the included tiles.
+//#define DEBUG_EXTENT
 
-using System.Drawing;
+using System.Globalization;
 using BruTile;
 using BruTile.MbTiles;
 using BruTile.Predefined;


### PR DESCRIPTION
This adds in code to fix the background colour issues for the various land masses that should have been rendered as cutouts in blocks of water, and also attempts to rotate text that is drawn upside down to the correct orientation where possible.