### PR TITLE
Call SkiaCanvas.ToPngByteArray later and add option to call ToSKImage instead

### DIFF
--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux.Tests/RenderTest.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux.Tests/RenderTest.cs
@@ -1,13 +1,8 @@
-using System.Diagnostics;
-using System.Drawing;
-using System.IO;
-using System.Threading.Tasks;
 using SQLite;
 using VexTile.Common.Enums;
 using VexTile.Data.Sources;
 using VexTile.Renderer.Mvt.AliFlux;
 using VexTile.Renderer.Mvt.AliFlux.Sources;
-using Xunit;
 
 namespace VexTile.Renderers.Mvt.AliFlux.Tests;
 
@@ -29,7 +24,8 @@ public class RenderTest
         var dataSource = new SqliteDataSource(val);
         var provider = new VectorTilesSource(dataSource);
         style.SetSourceProvider("openmaptiles", provider);
-        var tile = await TileRendererFactory.RenderAsync(style, canvas, new TileInfo(0, 0, 0));
+        await TileRendererFactory.RenderAsync(style, canvas, new TileInfo(0, 0, 0));
+        var tile = canvas.ToPngByteArray();
 
         Assert.NotNull(tile);
         Assert.True(tile.Length > 0);
@@ -59,7 +55,8 @@ public class RenderTest
 
         var provider = new PbfTileSource(bytes);
         style.SetSourceProvider("openmaptiles", provider);
-        var tile = await TileRendererFactory.RenderAsync(style, canvas, new TileInfo(0));
+        await TileRendererFactory.RenderAsync(style, canvas, new TileInfo(0));
+        var tile = canvas.ToPngByteArray();
 
         Assert.NotNull(tile);
         Assert.True(tile.Length > 0);
@@ -120,7 +117,8 @@ public class RenderTest
         style.SetSourceProvider("openmaptiles", provider);
 
         var info = new TileInfo(3, 1, 2, layerWhiteList:["water"]); // australia
-        var tile = await TileRendererFactory.RenderAsync(style, canvas, info);
+        await TileRendererFactory.RenderAsync(style, canvas, info);
+        var tile = canvas.ToPngByteArray();
 
         Assert.NotNull(tile);
         Assert.True(tile.Length > 0);

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/ICanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/ICanvas.cs
@@ -30,5 +30,5 @@ public interface ICanvas
 
     void DrawDebugBox(TileInfo tileData, SKColor color);
 
-    byte[] FinishDrawing();
+    byte[] ToPngByteArray(int quality = 80);
 }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SkiaCanvas.cs
@@ -698,12 +698,17 @@ public class SkiaCanvas : ICanvas
         });
     }
 
-    public byte[] FinishDrawing()
+    public byte[] ToPngByteArray(int quality = 80)
     {
         using var image = _surface.Snapshot();
-        using var data = image.Encode(SKEncodedImageFormat.Png, 80);
+        using var data = image.Encode(SKEncodedImageFormat.Png, quality);
         using var result = new MemoryStream();
         data.SaveTo(result);
         return result.ToArray();
+    }
+
+    public SKImage ToSKImage()
+    {
+        return _surface.Snapshot();
     }
 }

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRenderer.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRenderer.cs
@@ -29,18 +29,24 @@ public class TileRenderer : ITileRenderer
         style.SetSourceProvider(styleProviderString, provider);
     }
 
-    public Task<byte[]> RenderTileAsync(
+    public async Task<byte[]> RenderTileAsync(
         ICanvas canvas,
         int x, int y, double zoom,
         double sizeX = 512, double sizeY = 512,
         double scale = 1,
-        List<string> whiteListLayers = null) =>
-        TileRendererFactory.RenderAsync(style, canvas, new TileInfo(x, y, zoom, sizeX, sizeY, scale, whiteListLayers));
+        List<string> whiteListLayers = null)
+    {
+        await TileRendererFactory.RenderAsync(style, canvas, new TileInfo(x, y, zoom, sizeX, sizeY, scale, whiteListLayers));
+        return canvas.ToPngByteArray();
+    }
 
-    public Task<byte[]> RenderTileAsync(
+    public async Task<byte[]> RenderTileAsync(
         ICanvas canvas,
-        TileInfo tileData) =>
-        TileRendererFactory.RenderAsync(style, canvas, tileData);
+        TileInfo tileData)
+    {
+        await TileRendererFactory.RenderAsync(style, canvas, tileData);
+        return canvas.ToPngByteArray();
+    }
 
     protected virtual void Dispose(bool disposing)
     {

--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRendererFactory.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/TileRendererFactory.cs
@@ -34,7 +34,7 @@ public static class TileRendererFactory
     /// <param name="whiteListLayers">optional whitelist to reduce layers to render</param>
     /// <param name="overrideBackground">override the default background color</param>
     /// <returns>a png</returns>
-    public static async Task<byte[]> RenderAsync(VectorStyle style, ICanvas canvas, int x, int y, double zoom, double sizeX = 512, double sizeY = 512, double scale = 1, List<string> whiteListLayers = null, Color? overrideBackground = null) =>
+    public static async Task RenderAsync(VectorStyle style, ICanvas canvas, int x, int y, double zoom, double sizeX = 512, double sizeY = 512, double scale = 1, List<string> whiteListLayers = null, Color? overrideBackground = null) =>
         await RenderAsync(style, canvas,
             new TileInfo(x, y, zoom, sizeX, sizeY, scale, whiteListLayers), overrideBackground);
 
@@ -46,7 +46,18 @@ public static class TileRendererFactory
     /// <param name="tileData">contains all the tile information</param>
     /// <param name="overrideBackground">override the default background color</param>
     /// <returns>a png</returns>
-    public static async Task<byte[]> RenderAsync(VectorStyle style, ICanvas canvas, TileInfo tileData, Color? overrideBackground = null)
+    public static async Task RenderAsync(VectorStyle style, ICanvas canvas, TileInfo tileData, Color? overrideBackground = null)
+    {
+        await RenderToCanvasAsync(style, canvas, tileData, overrideBackground).ConfigureAwait(false);
+    }
+    /// <summary>
+    /// This is basically to avoid a lot of boilerplate
+    /// </summary>
+    /// <param name="style">the style to apply</param>
+    /// <param name="canvas">the canvas to draw on</param>
+    /// <param name="tileData">contains all the tile information</param>
+    /// <param name="overrideBackground">override the default background color</param>
+    public static async Task RenderToCanvasAsync(VectorStyle style, ICanvas canvas, TileInfo tileData, Color? overrideBackground = null)
     {
         Dictionary<Source, VectorTile> vectorTileCache = new();
         Dictionary<string, List<VectorTileLayer>> categorizedVectorLayers = new();
@@ -102,7 +113,7 @@ public static class TileRendererFactory
 
                     if (tile == null)
                     {
-                        return null;
+                        return;
                     }
 
                     // magic sauce! :p
@@ -192,12 +203,12 @@ public static class TileRendererFactory
             }
         }
 
-        return RenderVisualLayers(canvas, visualLayers);
+        RenderVisualLayers(canvas, visualLayers);                
     }
 
-    private static byte[] RenderVisualLayers(ICanvas canvas, List<VisualLayer> visualLayers)
+    private static void RenderVisualLayers(ICanvas canvas, List<VisualLayer> visualLayers)
     {
-        // defered rendering to preserve text drawing order
+        // deferred rendering to preserve text drawing order
         foreach (var layer in visualLayers.OrderBy(item => item.Brush.ZIndex))
         {
             if (layer.Type == VisualLayerType.Vector)
@@ -301,7 +312,5 @@ public static class TileRendererFactory
 #if USE_DEBUG_BOX
         canvas.DrawDebugBox(tileData, SKColors.Black);
 #endif
-
-        return canvas.FinishDrawing();
     }
 }

--- a/source/Mapping/VexTile.MbTiles.Mvt/MvtVectorTileSource.cs
+++ b/source/Mapping/VexTile.MbTiles.Mvt/MvtVectorTileSource.cs
@@ -208,19 +208,20 @@ public class MvtVectorTileSource : ITileSource
         if (IsTileIndexValid(index))
         {
             byte[] result;
-            
+
             var canvas = new SkiaCanvas();
 
             try
             {
-                result = await TileRendererFactory.RenderAsync(
+                await TileRendererFactory.RenderAsync(
                     _style,
                     canvas,
                     tileInfo.Index.Col, tileInfo.Index.Row, Convert.ToInt32(tileInfo.Index.Level),
                     256, 256, 1,
                     whiteListLayers: _whitelist);
+                result = canvas.ToPngByteArray();
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine(ex.Message);
                 return null;


### PR DESCRIPTION
This makes it possible to convert to SKImage instead of png byte array.

The Mapsui code could now look like this:

```cs

public async Task<byte[]?> GetTileAsync(TileInfo tileInfo)
{
    var canvas = new SkiaCanvas();
    await TileRendererFactory.RenderAsync(_vectorStyle, canvas, tileInfo.Index.Col, (int)Schema.GetMatrixHeight(tileInfo.Index.Level) - tileInfo.Index.Row - 1, tileInfo.Index.Level);
    return canvas.ToPngByteArray();
}
```
In a later stage we could make use of canvas.ToSKImage() instead, but this would need some reworks. The GetTileAsync should perhaps just return the raw data fetched from the tile source. For this we may not need VexTile at all. The conversion from the raw tile to SKImage could be done in the pre-renderer.