### PR TITLE
Remove .Result

### DIFF
--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Sources/VectorMbTilesSource.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/Sources/VectorMbTilesSource.cs
@@ -192,9 +192,10 @@ public class VectorTilesSource : IVectorTileSource
 
     private async Task<VectorTile?> GetCachedVectorTileAsync(int x, int y, int zoom)
     {
+        await _tileCacheLock.WaitAsync();
+        
         try
         {
-            await _tileCacheLock.WaitAsync();
             var key = x + "," + y + "," + zoom;
             if (tileCache.TryGetValue(key, out var existingTile))
             {
@@ -219,12 +220,7 @@ public class VectorTilesSource : IVectorTileSource
     }
 
     public Task<byte[]> GetTileAsync(int x, int y, int zoom)
-    {
-        if (GetRawTile(x, y, zoom) is { } rawTile)
-        {
-            return Task.FromResult(rawTile);
-        }
-
-        return Task.FromResult(Array.Empty<byte>());
-    }
+        => GetRawTile(x, y, zoom) is { } rawTile
+           ? Task.FromResult(rawTile)
+           : Task.FromResult(Array.Empty<byte>());
 }


### PR DESCRIPTION
There was still one .Result, probably because of the lock statement. The lock is replaced with a async SemaphoreSlim so that we can await.

There is no other .Result in the solution.

Some formatting changes were introduced by auto formatting of my IDE. Perhaps we should run dotnet format whitespace on the entire solution.