### PR TITLE
Fix concurrent exception

### DIFF
--- a/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SKColorFactory.cs
+++ b/source/AliFlux/VexTile.Renderers.Mvt.AliFlux/SKColorFactory.cs
@@ -45,7 +45,7 @@ public static class SKColorFactory
         // Use the packed ARGB from the color directly
         uint key = (uint)color;
 
-        Colours[key] = color;
+        _ = Colours.TryAdd(key, color);
 
 #if DEBUG_COLORS
         var hex = MakeKeyHex(color.Red, color.Green, color.Blue, color.Alpha);


### PR DESCRIPTION
The requests for tiles are executed in parallel. Because of the the Dictionary throws exception when adding the color. This is fixed by turning it into a ConcurrentDictionary.